### PR TITLE
Issue 6: Image tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'vendor/**/*'
     - 'node_modules/**/*'
     - 'bin/*'
+    - 'db/migrate/*'
   TargetRubyVersion: 2.5
 
 Layout/IndentArray:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem 'jquery-rails'
 
 gem 'webpacker', '~> 3.0'
 
+# Use ActsAsTaggableOn for tags
+gem 'acts-as-taggable-on', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.0.0)
+      activerecord (~> 5.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
@@ -223,6 +225,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   byebug
   capybara
   jquery-rails
@@ -245,4 +248,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,7 @@ class ImagesController < ApplicationController
   end
 
   def create
-    @image = Image.new(params.require(:image).permit(:url))
+    @image = Image.new(params.require(:image).permit(:url, :tag_list))
     if @image.save
       redirect_to @image
     else

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -13,7 +13,7 @@ class ImagesController < ApplicationController
   end
 
   def show
-    @url = Image.find(params[:id]).url
+    @image = Image.find(params[:id])
   end
 
   def index

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,7 @@ class ImagesController < ApplicationController
   end
 
   def create
-    @image = Image.create(params.require(:image).permit(:url))
+    @image = Image.new(params.require(:image).permit(:url))
     if @image.save
       redirect_to @image
     else

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,4 +2,5 @@ require 'uri'
 
 class Image < ApplicationRecord
   validates :url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
+  acts_as_taggable
 end

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -11,5 +11,8 @@
   <%= f.label :url %>
   <%= f.text_field :url %>
 
+  <%= f.label :tag_list %>
+  <%= f.text_field :tag_list, value: f.object.tag_list.to_s %>
+
   <%= f.submit "Save image URL" %>
 <% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,1 +1,8 @@
-<%= image_tag @url %>
+<%= image_tag @image.url %>
+
+<h3>Tags:</h3>
+<ul>
+  <% @image.tag_list.each do |tag| %>
+    <li><%= tag %></li>
+  <% end %>
+</ul>

--- a/db/migrate/20190114175037_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190114175037_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20190114175038_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190114175038_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20190114175039_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190114175039_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20190114175040_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190114175040_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20190114175041_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190114175041_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20190114175042_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190114175042_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_08_214656) do
+ActiveRecord::Schema.define(version: 2019_01_14_175042) do
 
   create_table "images", force: :cascade do |t|
     t.string "url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -24,7 +24,8 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
   test 'should create an image' do
     assert_difference 'Image.count' do
       post images_path, params: { image: {
-        url: 'https://learn.appfolio.com/apm/www/images/apm-logo-v2.png'
+        url: 'https://learn.appfolio.com/apm/www/images/apm-logo-v2.png',
+        image_tags: 'logo, appfolio'
       } }
     end
   end
@@ -39,6 +40,14 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select 'img' do |images|
       assert_equal 'https://picsum.photos/300/200/?image=2', images[0].attribute('src').value
       assert_equal 'https://picsum.photos/300/200/?image=1', images[1].attribute('src').value
+    end
+  end
+
+  test 'should create an image without tags' do
+    assert_difference 'Image.count' do
+      post images_path, params: { image: {
+        url: 'https://learn.appfolio.com/apm/www/images/apm-logo-v2.png'
+      } }
     end
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -50,4 +50,15 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
       } }
     end
   end
+
+  test 'show displays tags' do
+    @image_with_tags = Image.create(
+      url: 'https://learn.appfolio.com/apm/www/images/apm-logo-v2.png',
+      tag_list: 'sun, fun, run'
+    )
+    get image_path(@image_with_tags)
+    assert_select 'li', 'sun'
+    assert_select 'li', 'fun'
+    assert_select 'li', 'run'
+  end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -15,4 +15,12 @@ class ImageTest < ActiveSupport::TestCase
     image = Image.new(url: 'googlecom/image')
     assert_not_predicate(image, :valid?)
   end
+
+  test 'image with multiple tags can be created' do
+    image = Image.create(
+      url: 'https://picsum.photos/300/200/?image=3',
+      tag_list: 'sun, fun, run'
+    )
+    assert_equal image.tag_list, %w[sun fun run]
+  end
 end


### PR DESCRIPTION
- fixes a potential bug where images are made using `create` and `save` instead of `new` and `save`

- adds tags to the image model
- allows users to add tags when creating an image
- displays tags on the 'show' page for images