### PR TITLE
Issue 8: delete images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :production do
 end
 
 group :test do
+  gem 'ae_page_objects'
   gem 'capybara'
   gem 'selenium-webdriver'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       activerecord (~> 5.0)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    ae_page_objects (4.1.0)
+      capybara (~> 3.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.5.0)
@@ -226,6 +228,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on (~> 6.0)
+  ae_page_objects
   byebug
   capybara
   jquery-rails

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -22,4 +22,11 @@ class ImagesController < ApplicationController
     @images = @images.tagged_with(params['tag']) if params.key?('tag')
     flash.now[:alert] = "No images tagged with #{params['tag']}" if params.key?('tag') && @images.empty?
   end
+
+  def destroy
+    image = Image.find_by(id: params[:id])
+    image&.destroy
+    flash[:success] = 'You have successfully deleted the image.'
+    redirect_to images_path
+  end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -6,6 +6,7 @@ class ImagesController < ApplicationController
   def create
     @image = Image.new(params.require(:image).permit(:url, :tag_list))
     if @image.save
+      flash[:success] = 'You have successfully added an image.'
       redirect_to @image
     else
       render 'new'

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,8 +1,11 @@
-<ul>
-  <% if flash[:alert] %>
-    <div class="alert"><%= flash[:alert] %></div>
-  <% end %>
+<%= link_to 'New Image', new_image_path %>
+<ul id="images_list">
   <% @images.each do |image| %>
-    <li><%= image_tag image.url, class: 'index-img' %></li>
+    <li class="image_item">
+      <%= link_to (image_tag image.url, class: 'index-img'), image%>
+      <% image.tag_list.each do |tag| %>
+        <%= link_to(tag, images_path(tag: tag), class: 'tag') %>
+      <% end %>
+    </li>
   <% end %>
 </ul>

--- a/app/views/images/new.html.erb
+++ b/app/views/images/new.html.erb
@@ -1,7 +1,7 @@
 <h1>Store an image</h1>
-<%= form_for(@image, url: images_path) do |f| %>
+<%= form_for(@image, url: images_path, html: { class: 'form-group'} ) do |f| %>
   <% if @image.errors.any? %>
-    <ul>
+    <ul class="help-block">
       <% @image.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -6,3 +6,5 @@
     <li><%= link_to(tag, images_path(tag: tag), class: 'tag') %></li>
   <% end %>
 </ul>
+
+<%= link_to 'Delete Image', @image, method: :delete, data: { confirm: 'Are you sure?' } %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -3,6 +3,6 @@
 <h3>Tags:</h3>
 <ul>
   <% @image.tag_list.each do |tag| %>
-    <li><%= link_to(tag, images_path(tag: tag)) %></li>
+    <li><%= link_to(tag, images_path(tag: tag), class: 'tag') %></li>
   <% end %>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,12 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">
   </head>
   <body>
+    <h2><%= link_to 'Image Saver', root_path %></h2>
+
+    <% flash.each do |key, value| %>
+      <div class="alert alert-<%= key %>"><%= value %></div>
+    <% end %>
+
     <%= yield %>
 
     <!-- Optional JavaScript -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'images#index'
-  resources :images, only: %i[new create show index]
+  resources :images, only: %i[new create show index destroy]
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -78,6 +78,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
 
   test 'show page provides links to searching by tag' do
     get image_path(images(:rustic2))
-    assert_select 'a', count: 2
+    assert_select '.tag', count: 2
+    assert_select 'a', count: 4
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -81,4 +81,24 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select '.tag', count: 2
     assert_select 'a', count: 4
   end
+
+  test 'successfully delete an image' do
+    image = Image.create!(url: 'https://learn.appfolio.com/apm/www/images/apm-logo-v2.png')
+    assert_difference 'Image.count', -1 do
+      delete image_path(image.id)
+    end
+    assert_redirected_to images_path
+    assert_not Image.exists?(image.id)
+    follow_redirect!
+    assert_select '.alert-success', 'You have successfully deleted the image.'
+  end
+
+  test 'deleting an image that does not exist succeeds' do
+    assert_no_difference 'Image.count' do
+      delete image_path(-1)
+    end
+    assert_redirected_to images_path
+    follow_redirect!
+    assert_select '.alert-success', 'You have successfully deleted the image.'
+  end
 end

--- a/test/flow_test_helper.rb
+++ b/test/flow_test_helper.rb
@@ -9,6 +9,7 @@ require 'ae_page_objects/rails'
 module PageObjects
 end
 
+require 'page_objects/document.rb'
 Dir[File.dirname(__FILE__) + '/page_objects/**/*.rb'].each { |file| require file }
 
 class FlowTestCase < ActiveSupport::TestCase

--- a/test/flow_test_helper.rb
+++ b/test/flow_test_helper.rb
@@ -3,6 +3,13 @@ require 'test_helper'
 require 'active_support/test_case'
 require 'capybara/rails'
 require 'capybara/dsl'
+require 'ae_page_objects'
+require 'ae_page_objects/rails'
+
+module PageObjects
+end
+
+Dir[File.dirname(__FILE__) + '/page_objects/**/*.rb'].each { |file| require file }
 
 class FlowTestCase < ActiveSupport::TestCase
   include Capybara::DSL
@@ -28,3 +35,5 @@ end
 ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
 
 Capybara.default_driver = Capybara.javascript_driver
+
+AePageObjects::Element.include(PageObjects::Extensions::ElementInlineErrorMessage)

--- a/test/flows/images_crud_test.rb
+++ b/test/flows/images_crud_test.rb
@@ -6,7 +6,7 @@ class ImagesCrudTest < FlowTestCase
 
     new_image_page = images_index_page.add_new_image!
 
-    tags = %w(foo bar)
+    tags = %w[foo bar]
     new_image_page = new_image_page.create_image!(
       url: 'invalid',
       tags: tags.join(', ')
@@ -53,29 +53,29 @@ class ImagesCrudTest < FlowTestCase
     assert_equal 'You have successfully deleted the image.', images_index_page.flash_message(:success)
 
     assert_equal 1, images_index_page.images.count
-    refute images_index_page.showing_image?(url: ugly_cat_url)
+    assert_not images_index_page.showing_image?(url: ugly_cat_url)
     assert images_index_page.showing_image?(url: cute_puppy_url)
   end
 
   test 'view images associated with a tag' do
-    puppy_url_1 = 'http://www.pawderosa.com/images/puppies.jpg'
-    puppy_url_2 = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'
+    puppy_url1 = 'http://www.pawderosa.com/images/puppies.jpg'
+    puppy_url2 = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'
     cat_url = 'http://www.ugly-cat.com/ugly-cats/uglycat041.jpg'
     Image.create!([
-      { url: puppy_url_1, tag_list: 'superman, cute' },
-      { url: puppy_url_2, tag_list: 'cute, puppy' },
+      { url: puppy_url1, tag_list: 'superman, cute' },
+      { url: puppy_url2, tag_list: 'cute, puppy' },
       { url: cat_url, tag_list: 'cat, ugly' }
     ])
 
     images_index_page = PageObjects::Images::IndexPage.visit
-    [puppy_url_1, puppy_url_2, cat_url].each do |url|
+    [puppy_url1, puppy_url2, cat_url].each do |url|
       assert images_index_page.showing_image?(url: url)
     end
 
     images_index_page = images_index_page.images[1].click_tag!('cute')
 
     assert_equal 2, images_index_page.images.count
-    refute images_index_page.showing_image?(url: cat_url)
+    assert_not images_index_page.showing_image?(url: cat_url)
 
     images_index_page = images_index_page.clear_tag_filter!
     assert_equal 3, images_index_page.images.count

--- a/test/flows/images_crud_test.rb
+++ b/test/flows/images_crud_test.rb
@@ -1,0 +1,11 @@
+require 'flow_test_helper'
+
+class ImagesCrudTest < FlowTestCase
+  test 'extremely simple test to show page objects setup works' do
+    image_url = 'https://media3.giphy.com/media/EldfH1VJdbrwY/200.gif'
+    Image.create!(url: image_url)
+
+    images_index_page = PageObjects::Images::IndexPage.visit
+    assert_predicate images_index_page.node.find("img[src=\"#{image_url}\"]"), :present?
+  end
+end

--- a/test/flows/images_crud_test.rb
+++ b/test/flows/images_crud_test.rb
@@ -1,11 +1,83 @@
 require 'flow_test_helper'
 
 class ImagesCrudTest < FlowTestCase
-  test 'extremely simple test to show page objects setup works' do
+  test 'add an image' do
+    images_index_page = PageObjects::Images::IndexPage.visit
+
+    new_image_page = images_index_page.add_new_image!
+
+    tags = %w(foo bar)
+    new_image_page = new_image_page.create_image!(
+      url: 'invalid',
+      tags: tags.join(', ')
+    ).as_a(PageObjects::Images::NewPage)
+    assert_equal 'must be a valid URL', new_image_page.url.error_message
+
     image_url = 'https://media3.giphy.com/media/EldfH1VJdbrwY/200.gif'
-    Image.create!(url: image_url)
+    new_image_page.url.set(image_url)
+
+    image_show_page = new_image_page.create_image!
+    assert_equal 'You have successfully added an image.', image_show_page.flash_message(:success)
+
+    assert_equal image_url, image_show_page.image_url
+    assert_equal tags, image_show_page.tags
+
+    images_index_page = image_show_page.go_back_to_index!
+    assert images_index_page.showing_image?(url: image_url, tags: tags)
+  end
+
+  test 'delete an image' do
+    cute_puppy_url = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'
+    ugly_cat_url = 'http://www.ugly-cat.com/ugly-cats/uglycat041.jpg'
+    Image.create!([
+      { url: cute_puppy_url, tag_list: 'puppy, cute' },
+      { url: ugly_cat_url, tag_list: 'cat, ugly' }
+    ])
 
     images_index_page = PageObjects::Images::IndexPage.visit
-    assert_predicate images_index_page.node.find("img[src=\"#{image_url}\"]"), :present?
+    assert_equal 2, images_index_page.images.count
+    assert images_index_page.showing_image?(url: ugly_cat_url)
+    assert images_index_page.showing_image?(url: cute_puppy_url)
+
+    image_to_delete = images_index_page.images.find do |image|
+      image.url == ugly_cat_url
+    end
+    image_show_page = image_to_delete.view!
+
+    image_show_page.delete do |confirm_dialog|
+      assert_equal 'Are you sure?', confirm_dialog.text
+      confirm_dialog.dismiss
+    end
+
+    images_index_page = image_show_page.delete_and_confirm!
+    assert_equal 'You have successfully deleted the image.', images_index_page.flash_message(:success)
+
+    assert_equal 1, images_index_page.images.count
+    refute images_index_page.showing_image?(url: ugly_cat_url)
+    assert images_index_page.showing_image?(url: cute_puppy_url)
+  end
+
+  test 'view images associated with a tag' do
+    puppy_url_1 = 'http://www.pawderosa.com/images/puppies.jpg'
+    puppy_url_2 = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'
+    cat_url = 'http://www.ugly-cat.com/ugly-cats/uglycat041.jpg'
+    Image.create!([
+      { url: puppy_url_1, tag_list: 'superman, cute' },
+      { url: puppy_url_2, tag_list: 'cute, puppy' },
+      { url: cat_url, tag_list: 'cat, ugly' }
+    ])
+
+    images_index_page = PageObjects::Images::IndexPage.visit
+    [puppy_url_1, puppy_url_2, cat_url].each do |url|
+      assert images_index_page.showing_image?(url: url)
+    end
+
+    images_index_page = images_index_page.images[1].click_tag!('cute')
+
+    assert_equal 2, images_index_page.images.count
+    refute images_index_page.showing_image?(url: cat_url)
+
+    images_index_page = images_index_page.clear_tag_filter!
+    assert_equal 3, images_index_page.images.count
   end
 end

--- a/test/flows/images_crud_test.rb
+++ b/test/flows/images_crud_test.rb
@@ -26,6 +26,37 @@ class ImagesCrudTest < FlowTestCase
     assert images_index_page.showing_image?(url: image_url, tags: tags)
   end
 
+  test 'delete an image' do
+    cute_puppy_url = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'
+    ugly_cat_url = 'http://www.ugly-cat.com/ugly-cats/uglycat041.jpg'
+    Image.create!([
+      { url: cute_puppy_url, tag_list: 'puppy, cute' },
+      { url: ugly_cat_url, tag_list: 'cat, ugly' }
+    ])
+
+    images_index_page = PageObjects::Images::IndexPage.visit
+    assert_equal 6, images_index_page.images.count
+    assert images_index_page.showing_image?(url: ugly_cat_url)
+    assert images_index_page.showing_image?(url: cute_puppy_url)
+
+    image_to_delete = images_index_page.images.find do |image|
+      image.url == ugly_cat_url
+    end
+    image_show_page = image_to_delete.view!
+
+    image_show_page.delete do |confirm_dialog|
+      assert_equal 'Are you sure?', confirm_dialog.text
+      confirm_dialog.dismiss
+    end
+
+    images_index_page = image_show_page.delete_and_confirm!
+    assert_equal 'You have successfully deleted the image.', images_index_page.flash_message(:success)
+
+    assert_equal 5, images_index_page.images.count
+    assert_not images_index_page.showing_image?(url: ugly_cat_url)
+    assert images_index_page.showing_image?(url: cute_puppy_url)
+  end
+
   test 'view images associated with a tag' do
     puppy_url1 = 'http://www.pawderosa.com/images/puppies.jpg'
     puppy_url2 = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'

--- a/test/flows/images_crud_test.rb
+++ b/test/flows/images_crud_test.rb
@@ -11,7 +11,7 @@ class ImagesCrudTest < FlowTestCase
       url: 'invalid',
       tags: tags.join(', ')
     ).as_a(PageObjects::Images::NewPage)
-    assert_equal 'must be a valid URL', new_image_page.url.error_message
+    assert_equal 'Url is invalid', new_image_page.url.error_message
 
     image_url = 'https://media3.giphy.com/media/EldfH1VJdbrwY/200.gif'
     new_image_page.url.set(image_url)
@@ -24,37 +24,6 @@ class ImagesCrudTest < FlowTestCase
 
     images_index_page = image_show_page.go_back_to_index!
     assert images_index_page.showing_image?(url: image_url, tags: tags)
-  end
-
-  test 'delete an image' do
-    cute_puppy_url = 'http://ghk.h-cdn.co/assets/16/09/980x490/landscape-1457107485-gettyimages-512366437.jpg'
-    ugly_cat_url = 'http://www.ugly-cat.com/ugly-cats/uglycat041.jpg'
-    Image.create!([
-      { url: cute_puppy_url, tag_list: 'puppy, cute' },
-      { url: ugly_cat_url, tag_list: 'cat, ugly' }
-    ])
-
-    images_index_page = PageObjects::Images::IndexPage.visit
-    assert_equal 2, images_index_page.images.count
-    assert images_index_page.showing_image?(url: ugly_cat_url)
-    assert images_index_page.showing_image?(url: cute_puppy_url)
-
-    image_to_delete = images_index_page.images.find do |image|
-      image.url == ugly_cat_url
-    end
-    image_show_page = image_to_delete.view!
-
-    image_show_page.delete do |confirm_dialog|
-      assert_equal 'Are you sure?', confirm_dialog.text
-      confirm_dialog.dismiss
-    end
-
-    images_index_page = image_show_page.delete_and_confirm!
-    assert_equal 'You have successfully deleted the image.', images_index_page.flash_message(:success)
-
-    assert_equal 1, images_index_page.images.count
-    assert_not images_index_page.showing_image?(url: ugly_cat_url)
-    assert images_index_page.showing_image?(url: cute_puppy_url)
   end
 
   test 'view images associated with a tag' do
@@ -78,6 +47,6 @@ class ImagesCrudTest < FlowTestCase
     assert_not images_index_page.showing_image?(url: cat_url)
 
     images_index_page = images_index_page.clear_tag_filter!
-    assert_equal 3, images_index_page.images.count
+    assert_equal 7, images_index_page.images.count
   end
 end

--- a/test/page_objects/document.rb
+++ b/test/page_objects/document.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  class Document < AePageObjects::Document
+    def flash_message(message_type)
+      #TODO
+    end
+  end
+end

--- a/test/page_objects/document.rb
+++ b/test/page_objects/document.rb
@@ -1,7 +1,7 @@
 module PageObjects
   class Document < AePageObjects::Document
     def flash_message(message_type)
-      #TODO
+      # TODO
     end
   end
 end

--- a/test/page_objects/document.rb
+++ b/test/page_objects/document.rb
@@ -1,7 +1,7 @@
 module PageObjects
   class Document < AePageObjects::Document
     def flash_message(message_type)
-      # TODO
+      node.find(".alert.alert-#{message_type}").text
     end
   end
 end

--- a/test/page_objects/extensions/element_inline_error_message.rb
+++ b/test/page_objects/extensions/element_inline_error_message.rb
@@ -5,11 +5,9 @@ module PageObjects
         parent = find_parent
 
         Capybara.using_wait_time(0) do
-          begin
-            parent.find('.help-block').text
-          rescue Capybara::ElementNotFound
-            ''
-          end
+          parent.find('.help-block').text
+        rescue Capybara::ElementNotFound
+          ''
         end
       end
 

--- a/test/page_objects/extensions/element_inline_error_message.rb
+++ b/test/page_objects/extensions/element_inline_error_message.rb
@@ -1,0 +1,23 @@
+module PageObjects
+  module Extensions
+    module ElementInlineErrorMessage
+      def error_message
+        parent = find_parent
+
+        Capybara.using_wait_time(0) do
+          begin
+            parent.find('.help-block').text
+          rescue Capybara::ElementNotFound
+            ''
+          end
+        end
+      end
+
+      private
+
+      def find_parent
+        node.find(:xpath, "ancestor::*[contains(concat(' ',normalize-space(@class), ' '),' form-group ')][1]")
+      end
+    end
+  end
+end

--- a/test/page_objects/images/image_card.rb
+++ b/test/page_objects/images/image_card.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Images
+    class ImageCard < AePageObjects::Element
+      def url
+        node.find('img')[:src]
+      end
+
+      def tags
+        #TODO
+      end
+
+      def click_tag!(tag_name)
+        #TODO
+      end
+    end
+  end
+end

--- a/test/page_objects/images/image_card.rb
+++ b/test/page_objects/images/image_card.rb
@@ -6,11 +6,11 @@ module PageObjects
       end
 
       def tags
-        #TODO
+        # TODO
       end
 
       def click_tag!(tag_name)
-        #TODO
+        # TODO
       end
     end
   end

--- a/test/page_objects/images/image_card.rb
+++ b/test/page_objects/images/image_card.rb
@@ -6,11 +6,12 @@ module PageObjects
       end
 
       def tags
-        # TODO
+        node.all('.tag').map(&:text)
       end
 
       def click_tag!(tag_name)
-        # TODO
+        node.click_link(tag_name)
+        window.change_to(IndexPage)
       end
     end
   end

--- a/test/page_objects/images/index_page.rb
+++ b/test/page_objects/images/index_page.rb
@@ -5,7 +5,7 @@ module PageObjects
 
       collection :images, locator: '#TODO', item_locator: '#TODO', contains: ImageCard do
         def view!
-          #TODO
+          # TODO
         end
       end
 
@@ -15,11 +15,11 @@ module PageObjects
       end
 
       def showing_image?(url:, tags: nil)
-        #TODO
+        # TODO
       end
 
       def clear_tag_filter!
-        #TODO
+        # TODO
       end
     end
   end

--- a/test/page_objects/images/index_page.rb
+++ b/test/page_objects/images/index_page.rb
@@ -1,7 +1,26 @@
 module PageObjects
   module Images
-    class IndexPage < AePageObjects::Document
+    class IndexPage < PageObjects::Document
       path :images
+
+      collection :images, locator: '#TODO', item_locator: '#TODO', contains: ImageCard do
+        def view!
+          #TODO
+        end
+      end
+
+      def add_new_image!
+        node.click_on('New Image')
+        window.change_to(NewPage)
+      end
+
+      def showing_image?(url:, tags: nil)
+        #TODO
+      end
+
+      def clear_tag_filter!
+        #TODO
+      end
     end
   end
 end

--- a/test/page_objects/images/index_page.rb
+++ b/test/page_objects/images/index_page.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module Images
+    class IndexPage < AePageObjects::Document
+      path :images
+    end
+  end
+end

--- a/test/page_objects/images/index_page.rb
+++ b/test/page_objects/images/index_page.rb
@@ -3,7 +3,7 @@ module PageObjects
     class IndexPage < PageObjects::Document
       path :images
 
-      collection :images, locator: '#TODO', item_locator: '#TODO', contains: ImageCard do
+      collection :images, locator: '#images_list', item_locator: '.image_item', contains: ImageCard do
         def view!
           # TODO
         end
@@ -15,11 +15,15 @@ module PageObjects
       end
 
       def showing_image?(url:, tags: nil)
-        # TODO
+        images.any? do |image|
+          result = image.url == url
+          tags.present? ? (result && image.tags == tags) : result
+        end
       end
 
       def clear_tag_filter!
-        # TODO
+        node.click_on('Image Saver')
+        window.change_to(IndexPage)
       end
     end
   end

--- a/test/page_objects/images/index_page.rb
+++ b/test/page_objects/images/index_page.rb
@@ -5,7 +5,8 @@ module PageObjects
 
       collection :images, locator: '#images_list', item_locator: '.image_item', contains: ImageCard do
         def view!
-          # TODO
+          node.find('.index-img').click
+          window.change_to(ShowPage)
         end
       end
 

--- a/test/page_objects/images/new_page.rb
+++ b/test/page_objects/images/new_page.rb
@@ -1,12 +1,12 @@
 module PageObjects
   module Images
     class NewPage < PageObjects::Document
-      path #TODO
+      path # TODO
 
-      form_for :image #TODO
+      form_for :image # TODO
 
       def create_image!(url: nil, tags: nil)
-        #TODO
+        # TODO
       end
     end
   end

--- a/test/page_objects/images/new_page.rb
+++ b/test/page_objects/images/new_page.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module Images
+    class NewPage < PageObjects::Document
+      path #TODO
+
+      form_for :image #TODO
+
+      def create_image!(url: nil, tags: nil)
+        #TODO
+      end
+    end
+  end
+end

--- a/test/page_objects/images/new_page.rb
+++ b/test/page_objects/images/new_page.rb
@@ -1,12 +1,19 @@
 module PageObjects
   module Images
     class NewPage < PageObjects::Document
-      path # TODO
+      path :new_image
+      path :images
 
-      form_for :image # TODO
+      form_for :image do
+        element :url
+        element :tag_list
+      end
 
       def create_image!(url: nil, tags: nil)
-        # TODO
+        self.url.set(url) if url.present?
+        tag_list.set(tags) if tags.present?
+        node.click_button('Save image URL')
+        window.change_to(ShowPage, self.class)
       end
     end
   end

--- a/test/page_objects/images/show_page.rb
+++ b/test/page_objects/images/show_page.rb
@@ -1,0 +1,29 @@
+module PageObjects
+  module Images
+    class ShowPage < PageObjects::Document
+      path :image
+
+      def image_url
+        #TODO
+      end
+
+      def tags
+        #TODO
+      end
+
+      def delete
+        #TODO
+        yield node.driver.browser.switch_to.alert
+      end
+
+      def delete_and_confirm!
+        #TODO
+        window.change_to(IndexPage)
+      end
+
+      def go_back_to_index!
+        #TODO
+      end
+    end
+  end
+end

--- a/test/page_objects/images/show_page.rb
+++ b/test/page_objects/images/show_page.rb
@@ -4,25 +4,25 @@ module PageObjects
       path :image
 
       def image_url
-        #TODO
+        # TODO
       end
 
       def tags
-        #TODO
+        # TODO
       end
 
       def delete
-        #TODO
+        # TODO
         yield node.driver.browser.switch_to.alert
       end
 
       def delete_and_confirm!
-        #TODO
+        # TODO
         window.change_to(IndexPage)
       end
 
       def go_back_to_index!
-        #TODO
+        # TODO
       end
     end
   end

--- a/test/page_objects/images/show_page.rb
+++ b/test/page_objects/images/show_page.rb
@@ -4,11 +4,11 @@ module PageObjects
       path :image
 
       def image_url
-        # TODO
+        node.find('img')['src']
       end
 
       def tags
-        # TODO
+        node.all('.tag').map(&:text)
       end
 
       def delete
@@ -22,7 +22,8 @@ module PageObjects
       end
 
       def go_back_to_index!
-        # TODO
+        node.click_link('Image Saver')
+        window.change_to(IndexPage)
       end
     end
   end

--- a/test/page_objects/images/show_page.rb
+++ b/test/page_objects/images/show_page.rb
@@ -12,12 +12,12 @@ module PageObjects
       end
 
       def delete
-        # TODO
+        node.click_on('Delete Image')
         yield node.driver.browser.switch_to.alert
       end
 
       def delete_and_confirm!
-        # TODO
+        delete(&:accept)
         window.change_to(IndexPage)
       end
 


### PR DESCRIPTION
Closes Issue #8 

My first commit is pretty big. It fixes all the discrepancies between what the AEPageObjects expected my ropes project to look like and what it actually looks like, and finishes up most of the `TODO`s in their tests.

The second commit adds the ability to delete images.